### PR TITLE
Deprecated way of widget constructor fixed.

### DIFF
--- a/favorite-post-widget.php
+++ b/favorite-post-widget.php
@@ -14,7 +14,7 @@ class WeDevs_Favorite_Post_Widget extends WP_Widget {
      * */
     function WeDevs_Favorite_Post_Widget() {
         $widget_ops = array('classname' => 'wedevs-favorite-post' );
-        $this->WP_Widget( 'wedevs-favorite-post', __( 'Favorite post', 'wfp' ), $widget_ops );
+        parent::__construct( 'wedevs-favorite-post', __( 'Favorite post', 'wfp' ), $widget_ops );
     }
 
     /**


### PR DESCRIPTION
`$this->WP_Widget( 'wedevs-favorite-post', __( 'Favorite post', 'wfp' ), $widget_ops );`
Calling this way the constructor method of parent class has been deprecated since version 4.3.0
The fixed piece of code is-
`parent::__construct( 'wedevs-favorite-post', __( 'Favorite post', 'wfp' ), $widget_ops );`

Thank you.
